### PR TITLE
Add delete support

### DIFF
--- a/lib/arc_ecto/definition.ex
+++ b/lib/arc_ecto/definition.ex
@@ -30,6 +30,10 @@ defmodule Arc.Ecto.Definition do
       end
 
       def url(f, v, options), do: super(f, v, options)
+      
+      def delete({%{file_name: file_name, updated_at: _updated_at}, scope}), do: super({file_name, scope})
+
+      def delete(args), do: super(args)
     end
   end
 end


### PR DESCRIPTION
Hello, I have a problem with deleting photo.

This code dont work:
```PhotoUploader.delete({photo.file, photo})```

and this work correctly:
```PhotoUploader.delete({photo.file.file_name, photo})```

I suggest the first variant to deleting photo with type of PhotoUploader.Type.